### PR TITLE
upgrade unicode-display_width to 1.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.6)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.7.0)
     verbs (2.1.4)
       activesupport (>= 2.3.4)
       i18n


### PR DESCRIPTION
Removes ugly deprecation warnings:

```
$ bundle exec rake spec
NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.
Gem.gunzip called from /app/vendor/bundle/ruby/2.6.0/gems/unicode-display_width-1.3.0/lib/unicode/display_width/index.rb:5.
/usr/local/bin/ruby -I/app/vendor/bundle/ruby/2.6.0/gems/rspec-core-3.7.1/lib:/app/vendor/bundle/ruby/2.6.0/gems/rspec-support-3.7.1/lib /app/vendor/bundle/ruby/2.6.0/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.
Gem.gunzip called from /app/vendor/bundle/ruby/2.6.0/gems/unicode-display_width-1.3.0/lib/unicode/display_width/index.rb:5.
```