### PR TITLE
TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,3 @@ install:
   - docker-compose run --rm api bundle exec rake db:setup
 sevices:
   - docker
-rvm:
-  - 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
-script: bundle exec rake spec
+script: docker-compose run --rm api bundle exec rspec
 install:
-  - gem install bundler:2.1.4
-  - bundle install --jobs=3 --retry=3
+  - cp .env.example .env
+  - docker-compose run --rm --no-deps api bundle install
+  - docker-compose run --rm api bundle exec rake db:setup
+sevices:
+  - docker
 rvm:
   - 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 script: docker-compose run --rm api bundle exec rspec
 install:
   - cp .env.example .env
+  - docker-compose run --rm --no-deps api gem install bundler:2.1.4
   - docker-compose run --rm --no-deps api bundle install
   - docker-compose run --rm api bundle exec rake db:setup
 sevices:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 script: docker-compose run --rm api bundle exec rake spec
 install:
   - cp .env.example .env
-  - docker-compose run --rm --no-deps api bundle install
   - docker-compose run --rm api bundle exec rake db:setup
 sevices:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-script: docker-compose run --rm api bundle exec rspec
+script: docker-compose run --rm api bundle exec rake spec
 install:
   - cp .env.example .env
   - docker-compose run --rm --no-deps api gem install bundler:2.1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 script: docker-compose run --rm api bundle exec rake spec
 install:
   - cp .env.example .env
-  - docker-compose run --rm --no-deps api gem install bundler:2.1.4
   - docker-compose run --rm --no-deps api bundle install
   - docker-compose run --rm api bundle exec rake db:setup
 sevices:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+script: bundle exec rake spec
+install:
+  - gem install bundler:2.1.4
+  - bundle install --jobs=3 --retry=3
+rvm:
+  - 2.6.5


### PR DESCRIPTION
This adds basic TravisCI integration that just runs specs.

Someone with access to  the [factn](https://github.com/factn) organization needs to authenticate with TravisCI before it starts working. Instructions [here](https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci-using-github).

If you would like to see example build, [here is one](https://travis-ci.org/github/skrobul/coronadonor-api/builds/664952625) executed against my fork.